### PR TITLE
ci: Automatically approve settings updates

### DIFF
--- a/.github/workflows/settings-ci.yml
+++ b/.github/workflows/settings-ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: yamllint
         uses: reviewdog/action-yamllint@v1.14.0
         with:
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           yamllint_flags: "slack-archive.yaml"
 
   approve:

--- a/.github/workflows/settings-ci.yml
+++ b/.github/workflows/settings-ci.yml
@@ -20,9 +20,9 @@ jobs:
         run: |
           files=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }})
           if [[ "$files" == "slack-archive.yaml" ]]; then
-            echo "only_changed=true" >> $GITHUB_ENV
+            echo "only_changed=true" >> $GITHUB_OUTPUT
           else
-            echo "only_changed=false" >> $GITHUB_ENV
+            echo "only_changed=false" >> $GITHUB_OUTPUT
   validate:
     needs: check_files_changed
     if: needs.check_files_changed.outputs.only_changed == 'true'

--- a/.github/workflows/settings-ci.yml
+++ b/.github/workflows/settings-ci.yml
@@ -44,7 +44,7 @@ jobs:
           echo ${{ steps.yq_list.outputs.result }} | ( echo ${{ steps.yq_reg.outputs.result }} | diff /dev/fd/3 -) 3<&0
           exit 1
 
-  yamlLint:
+  yamllint:
     needs: check_files_changed
     if: needs.check_files_changed.outputs.only_changed == 'true'
     runs-on: ubuntu-latest
@@ -57,7 +57,7 @@ jobs:
           yamllint_flags: "slack-archive.yaml"
 
   approve:
-    needs: [validate, yamlLint]
+    needs: [validate, yamllint]
     runs-on: ubuntu-latest
     steps:
       - name: Approve a PR

--- a/.github/workflows/settings-ci.yml
+++ b/.github/workflows/settings-ci.yml
@@ -29,11 +29,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: mikefarah/yq@master
+      - uses: mikefarah/yq@v4.44.1
         id: yq_list
         with:
           cmd: yq eval '.targetChannels' slack-archive.yaml
-      - uses: mikefarah/yq@master
+      - uses: mikefarah/yq@v4.44.1
         id: yq_reg
         with:
           cmd: yq eval '.targetChannels | with_entries(select(.key|test("^C[A-Z0-9]{10}") and .value != null))' slack-archive.yaml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: yamllint
-        uses: reviewdog/action-yamllint@v1
+        uses: reviewdog/action-yamllint@v1.14.0
         with:
           github_token: ${{ secrets.github_token }}
           yamllint_flags: "slack-archive.yaml"

--- a/.github/workflows/settings-ci.yml
+++ b/.github/workflows/settings-ci.yml
@@ -1,0 +1,67 @@
+name: Validate Settings
+
+on:
+  pull_request:
+    paths:
+      - "slack-archive.yaml"
+
+permissions:
+  pull-requests: write
+
+jobs:
+  check_files_changed:
+    runs-on: ubuntu-latest
+    outputs:
+      only_changed: ${{ steps.check.outputs.only_changed }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check if only slack-archive.yaml changed
+        id: check
+        run: |
+          files=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }})
+          if [[ "$files" == "slack-archive.yaml" ]]; then
+            echo "only_changed=true" >> $GITHUB_ENV
+          else
+            echo "only_changed=false" >> $GITHUB_ENV
+  validate:
+    needs: check_files_changed
+    if: needs.check_files_changed.outputs.only_changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: mikefarah/yq@master
+        id: yq_list
+        with:
+          cmd: yq eval '.targetChannels' slack-archive.yaml
+      - uses: mikefarah/yq@master
+        id: yq_reg
+        with:
+          cmd: yq eval '.targetChannels | with_entries(select(.key|test("^C[A-Z0-9]{10}") and .value != null))' slack-archive.yaml
+      - name: Validate targetChannels
+        if: steps.yq_list.outputs.result != steps.yq_reg.outputs.result
+        run: |
+          echo "Validation failed."
+          echo ${{ steps.yq_list.outputs.result }} | ( echo ${{ steps.yq_reg.outputs.result }} | diff /dev/fd/3 -) 3<&0
+          exit 1
+
+  yamlLint:
+    needs: check_files_changed
+    if: needs.check_files_changed.outputs.only_changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: yamllint
+        uses: reviewdog/action-yamllint@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          yamllint_flags: "slack-archive.yaml"
+
+  approve:
+    needs: [validate, yamlLint]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Approve a PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,2 @@
+rules:
+  document-start: disable


### PR DESCRIPTION
## 動機
slack-archive.yamlのバリテーションを行うことでReviewを通さずに自動でapproveされるようになるCIを追加したい

## CIの中身
- check_files_changed
  - `.on.pull_request.paths`は`slack-archive.yaml`を含むPRならそれ以外の編集でも動いちゃうので、`slack-archive.yaml`以外のdiffが含まれる場合はこれ以降のJobをskipする(approveをしない)
- validate
  - [yq](https://github.com/mikefarah/yq)で設定ファイルの`.targetChannels`が適切なIDの形かを正規表現でチェック
- yamlLint
  -  lint目的ではなく、yamlのフォーマットが間違っていないかをチェックしたい(yqが動く時点でフォーマットが正しいのでいらないかも)
- approve
  - validateとyamlLintに成功した場合にのみ、ghコマンドのpr reviewを使用してapproveをする